### PR TITLE
Fix repeated logger creation

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/api/attributes/AccessoryAttributeBuilder.java
+++ b/common/src/main/java/io/wispforest/accessories/api/attributes/AccessoryAttributeBuilder.java
@@ -21,7 +21,7 @@ import java.util.*;
  */
 public final class AccessoryAttributeBuilder {
 
-    private final Logger LOGGER = LogUtils.getLogger();
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     private final Map<Holder<Attribute>, Map<ResourceLocation, AttributeModificationData>> exclusiveAttributes = new HashMap<>();
     private final Multimap<Holder<Attribute>, AttributeModificationData> stackedAttributes = LinkedHashMultimap.create();


### PR DESCRIPTION
# This PR
This PR prevents new loggers from being created for each instance of `AccessoryAttributeBuilder`, by making the logger static.

# The Issue
`AccessoryAttributeBuilder` is created multiple times each time `AccessoriesEventHandler.onLivingEntityTick()` is called. This means that the logger was re-created multiple times for each player for each tick.

# Testing
This fix has been tested on my server and seems to have fixed some of the server-lag issues we were experiencing.