### PR TITLE
Fix null collection copy crash on holder cache lookup

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/impl/caching/AccessoriesHolderLookupCache.java
+++ b/common/src/main/java/io/wispforest/accessories/impl/caching/AccessoriesHolderLookupCache.java
@@ -92,8 +92,7 @@ public class AccessoriesHolderLookupCache extends EquipmentLookupCache {
 
             for (var value : this.containerLookupCacheMap.values()) {
                 var x = value.getAllEquipped();
-                if (x == null) x = List.of();
-                this.getAllEquipped.addAll(x);
+                if (x != null) this.getAllEquipped.addAll(x);
             }
         }
 

--- a/common/src/main/java/io/wispforest/accessories/impl/caching/AccessoriesHolderLookupCache.java
+++ b/common/src/main/java/io/wispforest/accessories/impl/caching/AccessoriesHolderLookupCache.java
@@ -91,7 +91,9 @@ public class AccessoriesHolderLookupCache extends EquipmentLookupCache {
             this.getAllEquipped = new ArrayList<>();
 
             for (var value : this.containerLookupCacheMap.values()) {
-                this.getAllEquipped.addAll(value.getAllEquipped());
+                var x = value.getAllEquipped();
+                if (x == null) x = List.of();
+                this.getAllEquipped.addAll(x);
             }
         }
 


### PR DESCRIPTION
Simple fix of an issue that arises any time holder cached lookup is called over NBT-strict entities