### PR TITLE
Fix crash with tab page count & valid group size mismatch

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/client/gui/AccessoriesScreen.java
+++ b/common/src/main/java/io/wispforest/accessories/client/gui/AccessoriesScreen.java
@@ -780,13 +780,18 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
                 .sorted(Comparator.comparingInt(SlotGroup::order).reversed())
                 .toList();
 
+        List<SlotGroup> visibleGroups;
         if (Math.ceil(groups.size() / 9f) > 1) {
             var lowerBound = (this.currentTabPage - 1) * 9;
             var upperBound = lowerBound + 9;
 
             if (upperBound > groups.size()) upperBound = groups.size();
 
-            groups = groups.subList(lowerBound, upperBound);
+            // Don't need to look at groups that won't affect visible group indices
+            groups = groups.subList(0, upperBound);
+            visibleGroups = groups.subList(lowerBound, groups.size());
+        } else {
+            visibleGroups = groups;
         }
 
         var bottomIndex = this.menu.scrolledIndex;
@@ -848,7 +853,7 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
 
         var groupValues = new HashMap<SlotGroup, SlotGroupData>();
 
-        for (var group : groups) {
+        for (var group : visibleGroups) {
             if ((yOffset + height) > maxHeight) break;
 
             var selected = selectedGroup.contains(group.name());

--- a/common/src/main/java/io/wispforest/accessories/client/gui/AccessoriesScreen.java
+++ b/common/src/main/java/io/wispforest/accessories/client/gui/AccessoriesScreen.java
@@ -557,7 +557,7 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
             accessoriesSlots++;
         }
 
-        if (tabPageCount() > 1) {
+        if (this.validTabPageCount() > 1) {
             this.tabDownButton = this.addRenderableWidget(
                     Button.builder(Component.literal("⬆"), button -> this.onTabPageChange(true))
                             .bounds(this.leftPos - 56, this.topPos - 11, 10, 10)
@@ -574,7 +574,7 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
 
             this.tabUpButton.setTooltip(Tooltip.create(Component.literal("Page 2")));
 
-            this.tabUpButton.active = tabPageCount() != 1;
+            this.tabUpButton.active = true;
         }
 
         this.menu.setScrollEvent(this::updateAccessoryToggleButtons);
@@ -585,7 +585,10 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
     }
 
     private void onTabPageChange(boolean isDown) {
-        if ((this.currentTabPage <= 1 && isDown) || (this.currentTabPage > tabPageCount() && !isDown)) {
+        if (this.currentTabPage <= 1 && isDown) return;
+
+        int tabPageCount = this.validTabPageCount();
+        if (this.currentTabPage > tabPageCount && !isDown) {
             return;
         }
 
@@ -606,7 +609,7 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
             this.tabDownButton.active = true;
         }
 
-        if (this.currentTabPage >= tabPageCount()) {
+        if (this.currentTabPage >= tabPageCount) {
             this.tabUpButton.active = false;
         } else if (!this.tabUpButton.active) {
             this.tabUpButton.active = true;
@@ -767,13 +770,17 @@ public class AccessoriesScreen extends AbstractContainerScreen<AccessoriesMenu> 
         return (int) Math.ceil(groups.size() / 9f);
     }
 
+    public int validTabPageCount() {
+        return (int) Math.ceil(this.getMenu().validGroups().size() / 9f);
+    }
+
     // MAX 9
     private Map<SlotGroup, SlotGroupData> getGroups(int x, int y) {
         var groups = this.getMenu().validGroups().stream()
                 .sorted(Comparator.comparingInt(SlotGroup::order).reversed())
                 .toList();
 
-        if (tabPageCount() > 1) {
+        if (Math.ceil(groups.size() / 9f) > 1) {
             var lowerBound = (this.currentTabPage - 1) * 9;
             var upperBound = lowerBound + 9;
 


### PR DESCRIPTION
In the original accessory screen with the accessorify mod installed, clicking the down arrow would crash the client. Original method is left intact, as I'm not too sure if other mods reference it.

Also makes slot group indices consider sizes of groups on previous pages, where before the top group started at slot index 0 regardless of the page.