### PR TITLE
Add validation for previous item slot index

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/impl/ExpandedSimpleContainer.java
+++ b/common/src/main/java/io/wispforest/accessories/impl/ExpandedSimpleContainer.java
@@ -72,6 +72,7 @@ public class ExpandedSimpleContainer extends SimpleContainer implements Iterable
     }
 
     public void setPreviousItem(int slot, ItemStack stack) {
+        if(!validIndex(slot)) return;
         this.previousItems.set(slot, stack);
         if (!stack.isEmpty() && stack.getCount() > this.getMaxStackSize()) {
             stack.setCount(this.getMaxStackSize());


### PR DESCRIPTION
This pull request adds a small safety check to the `setPreviousItem` method in `ExpandedSimpleContainer`, preventing out-of-bounds errors when an invalid slot index is provided.

* Added a guard clause to `setPreviousItem` to return early if the slot index is invalid, improving robustness and preventing potential runtime errors.


Related crash:
```
net.minecraft.class_148: Ticking player
    at knot//net.minecraft.class_3222.method_14226(class_3222.java:574)
    at knot//net.minecraft.class_3244.mixinextras$bridge$method_14226$261(class_3244.java)
    at knot//com.bawnorton.neruina.handler.TickHandler.safelyTickPlayer(TickHandler.java:136)
    at knot//net.minecraft.class_3244.wrapOperation$kfl000$neruina$catchTickingPlayer$notTheCauseOfTickLag(class_3244.java:15954)
    at knot//net.minecraft.class_3244.method_18784(class_3244.java:269)
    at knot//net.minecraft.class_2535.method_10754(class_2535.java:259)
    at knot//net.minecraft.class_3242.method_14357(class_3242.java:172)
    at knot//net.minecraft.server.MinecraftServer.method_3813(MinecraftServer.java:908)
    at knot//net.minecraft.class_3176.method_3813(class_3176.java:283)
    at knot//net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:824)
    at knot//net.minecraft.server.MinecraftServer.handler$dcf000$carpet$modifiedRunLoop(MinecraftServer.java:42942)
    at knot//net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:650)
    at knot//net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:265)
    at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
    at java.base/java.util.Arrays$ArrayList.set(Arrays.java:4271)
    at knot//net.minecraft.class_2371.set(class_2371.java:54)
    at knot//io.wispforest.accessories.impl.ExpandedSimpleContainer.setPreviousItem(ExpandedSimpleContainer.java:75)
    at knot//io.wispforest.accessories.impl.ExpandedSimpleContainer.lambda$setFromPrev$0(ExpandedSimpleContainer.java:236)
    at java.base/java.lang.Iterable.forEach(Iterable.java:75)
    at knot//io.wispforest.accessories.impl.ExpandedSimpleContainer.setFromPrev(ExpandedSimpleContainer.java:236)
    at knot//io.wispforest.accessories.impl.AccessoriesCapabilityImpl.lambda$reset$0(AccessoriesCapabilityImpl.java:96)
    at java.base/java.util.Map.forEach(Map.java:733)
    at knot//io.wispforest.accessories.impl.AccessoriesCapabilityImpl.reset(AccessoriesCapabilityImpl.java:93)
    at knot//com.b1n_ry.yigd.compat.AccessoriesCompat.lambda$clear$0(AccessoriesCompat.java:35)
    at java.base/java.util.Optional.ifPresent(Optional.java:178)
    at knot//com.b1n_ry.yigd.compat.AccessoriesCompat.clear(AccessoriesCompat.java:35)
    at knot//com.b1n_ry.yigd.components.InventoryComponent.clearPlayer(InventoryComponent.java:790)
    at knot//com.b1n_ry.yigd.DeathHandler.onPlayerDeath(DeathHandler.java:40)
    at knot//net.minecraft.class_1309.handler$badb001$yigd$drop(class_1309.java:6143)
    at knot//net.minecraft.class_1309.method_16080(class_1309.java)
    at knot//net.minecraft.class_3222.method_6078(class_3222.java:643)
    at knot//net.minecraft.class_1309.method_5643(class_1309.java:1222)
    at knot//net.minecraft.class_1657.method_5643(class_1657.java:928)
    at knot//net.minecraft.class_3222.handler$bao001$arc$hurt(class_3222.java:6297)
    at knot//net.minecraft.class_3222.method_5643(class_3222.java:732)
    at knot//net.minecraft.class_1297.method_5670(class_1297.java:518)
    at knot//net.minecraft.class_1309.method_5670(class_1309.java:367)
    at knot//net.minecraft.class_1297.method_5773(class_1297.java:474)
    at knot//net.minecraft.class_1309.method_5773(class_1309.java:2380)
    at knot//net.minecraft.class_1657.method_5773(class_1657.java:283)
    at knot//net.minecraft.class_3222.method_14226(class_3222.java:510)
    ... 13 more
    ```