### PR TITLE
Fix AbstractContainerScreenMixin crashing on NeoForge

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/mixin/client/AbstractContainerScreenMixin.java
+++ b/common/src/main/java/io/wispforest/accessories/mixin/client/AbstractContainerScreenMixin.java
@@ -55,9 +55,4 @@ public abstract class AbstractContainerScreenMixin implements ContainerScreenExt
 
         original.call(instance, function, texture, x, y, width, height);
     }
-
-    @WrapOperation(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;matches(II)Z"))
-    private boolean accessories$adjustCloseCheck(KeyMapping instance, int keysym, int scancode, Operation<Boolean> original) {
-        return original.call(instance, keysym, scancode) || original.call(AccessoriesClient.OPEN_SCREEN, keysym, scancode);
-    }
 }

--- a/fabric/src/main/java/io/wispforest/accessories/fabric/mixin/client/AbstractContainerScreenMixin.java
+++ b/fabric/src/main/java/io/wispforest/accessories/fabric/mixin/client/AbstractContainerScreenMixin.java
@@ -3,7 +3,9 @@ package io.wispforest.accessories.fabric.mixin.client;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import io.wispforest.accessories.client.AccessoriesClient;
 import io.wispforest.accessories.pond.ContainerScreenExtension;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.inventory.Slot;
@@ -29,5 +31,10 @@ public abstract class AbstractContainerScreenMixin implements ContainerScreenExt
         var override = this.isHovering_Rendering(this.hoveredSlot, mouseX, mouseY);
 
         if (override == null || override) original.call(instance, guiGraphics);
+    }
+
+    @WrapOperation(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;matches(II)Z", ordinal = 0))
+    private boolean accessories$adjustCloseCheck(KeyMapping instance, int keysym, int scancode, Operation<Boolean> original) {
+        return original.call(instance, keysym, scancode) || original.call(AccessoriesClient.OPEN_SCREEN, keysym, scancode);
     }
 }

--- a/neoforge/src/main/java/io/wispforest/accessories/neoforge/mixin/client/AbstractContainerScreenMixin.java
+++ b/neoforge/src/main/java/io/wispforest/accessories/neoforge/mixin/client/AbstractContainerScreenMixin.java
@@ -3,7 +3,10 @@ package io.wispforest.accessories.neoforge.mixin.client;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.platform.InputConstants;
+import io.wispforest.accessories.client.AccessoriesClient;
 import io.wispforest.accessories.pond.ContainerScreenExtension;
+import net.minecraft.client.KeyMapping;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.inventory.Slot;
@@ -31,5 +34,10 @@ public abstract class AbstractContainerScreenMixin implements ContainerScreenExt
         var override = this.isHovering_Rendering(this.hoveredSlot, mouseX, mouseY);
 
         if (override == null || override) original.call(instance, guiGraphics);
+    }
+
+    @WrapOperation(method = "keyPressed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;isActiveAndMatches(Lcom/mojang/blaze3d/platform/InputConstants$Key;)Z", ordinal = 0))
+    private boolean accessories$adjustCloseCheck(KeyMapping instance, InputConstants.Key mouseKey, Operation<Boolean> original) {
+        return original.call(instance, mouseKey) || original.call(AccessoriesClient.OPEN_SCREEN, mouseKey);
     }
 }


### PR DESCRIPTION
The `keyPressed` method has different params on NeoForge and Fabric, so I moved the mixin out of common and into each platform's respective AbstractContainerScreenMixin class and fixed the params. It looks like this fix was already implemented in 1.21.6+ branches, just not in 1.21.5.

This resolves #330.