### PR TITLE
1.21.4: Ensure SyncEntireContainer is not sent before client has started loading in

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/impl/AccessoriesCapabilityImpl.java
+++ b/common/src/main/java/io/wispforest/accessories/impl/AccessoriesCapabilityImpl.java
@@ -26,6 +26,8 @@ import io.wispforest.endec.SerializationContext;
 import io.wispforest.endec.util.MapCarrier;
 import io.wispforest.owo.serialization.RegistriesAttribute;
 import it.unimi.dsi.fastutil.Pair;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -96,11 +98,17 @@ public class AccessoriesCapabilityImpl implements AccessoriesCapability, Instanc
 
         if (!(this.entity instanceof ServerPlayer serverPlayer) || serverPlayer.connection == null) return;
 
-        var carrier = NbtMapCarrier.of();
+        RegistryAccess registryAccess = this.entity.level().registryAccess();
 
-        holder.write(carrier, SerializationContext.attributes(RegistriesAttribute.of(this.entity.level().registryAccess())));
+        // Defer update packet until end of tick because client may still be connecting at this point
+        MinecraftServer server = serverPlayer.server;
+        server.schedule(server.wrapRunnable(() -> {
+            var carrier = NbtMapCarrier.of();
 
-        AccessoriesNetworking.sendToTrackingAndSelf(serverPlayer, new SyncEntireContainer(serverPlayer.getId(), carrier));
+            holder.write(carrier, SerializationContext.attributes(RegistriesAttribute.of(registryAccess)));
+
+            AccessoriesNetworking.sendToTrackingAndSelf(serverPlayer, new SyncEntireContainer(serverPlayer.getId(), carrier));
+        }));
     }
 
     private boolean updateContainersLock = false;

--- a/common/src/main/java/io/wispforest/accessories/impl/AccessoriesCapabilityImpl.java
+++ b/common/src/main/java/io/wispforest/accessories/impl/AccessoriesCapabilityImpl.java
@@ -98,10 +98,10 @@ public class AccessoriesCapabilityImpl implements AccessoriesCapability, Instanc
 
         if (!(this.entity instanceof ServerPlayer serverPlayer) || serverPlayer.connection == null) return;
 
-        RegistryAccess registryAccess = this.entity.level().registryAccess();
+        var registryAccess = this.entity.level().registryAccess();
 
         // Defer update packet until end of tick because client may still be connecting at this point
-        MinecraftServer server = serverPlayer.server;
+        var server = serverPlayer.server;
         server.schedule(server.wrapRunnable(() -> {
             var carrier = NbtMapCarrier.of();
 


### PR DESCRIPTION
Fixing the root cause of the stack trace shown in https://github.com/wisp-forest/owo-lib/issues/466

We should wait until the client has spawned their player object before we send packets that concern the player. There is probably a better way of doing this but I'm not sure :)