### PR TITLE
1.21.4: Avoid mixin access errors on server

### DIFF
--- a/common/src/main/resources/accessories-common.mixins.json
+++ b/common/src/main/resources/accessories-common.mixins.json
@@ -40,8 +40,7 @@
     "client.owo.OwoReiPluginMixin",
     "client.owo.ScissorStackMixin",
     "client.owo.ScrollContainerMixin",
-    "sodium.MPOATVConstructingVertexConsumerMixin_SodiumImpl",
-    "SimpleJsonResourceReloadListenerAccessor"
+    "sodium.MPOATVConstructingVertexConsumerMixin_SodiumImpl"
   ],
   "mixins": [
     "ApplyBonusCountMixin",
@@ -70,6 +69,7 @@
     "PowderSnowBlockMixin",
     "RegistryOpsAccessor",
     "ServerChunkLoadingManagerAccessor",
+    "SimpleJsonResourceReloadListenerAccessor",
     "SlotAccessor",
     "StateHolderAccessor",
     "StriderMixin",


### PR DESCRIPTION
This PR fixes the following exception, which prevents loading the mod on the server when built from source.

```
java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'accessories' at 'io.wispforest.accessories.fabric.AccessoriesFabric'!
        at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$0(FabricLoaderImpl.java:409) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:407) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.Hooks.startServer(Hooks.java:63) ~[fabric-loader-0.18.4.jar:?]
        at knot/net.minecraft.server.Main.main(Main.java:113) [server-intermediary.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514) [fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72) [fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.18.4.jar:?]
Caused by: java.lang.ExceptionInInitializerError
        at knot/io.wispforest.accessories.Accessories.init(Accessories.java:116) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.fabric.AccessoriesFabric.onInitialize(AccessoriesFabric.java:77) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:405) ~[fabric-loader-0.18.4.jar:?]
        ... 6 more
Caused by: java.lang.RuntimeException: Mixin transformation of io.wispforest.accessories.mixin.SimpleJsonResourceReloadListenerAccessor failed
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getPostMixinClassByteArray(KnotClassDelegate.java:440) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.tryLoadClass(KnotClassDelegate.java:336) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.loadClass(KnotClassDelegate.java:231) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:119) ~[fabric-loader-0.18.4.jar:?]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
        at knot/io.wispforest.accessories.utils.EndecDataLoader.setupCodec(EndecDataLoader.java:57) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.utils.EndecDataLoader.<init>(EndecDataLoader.java:53) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.utils.ManagedEndecDataLoader.<init>(ManagedEndecDataLoader.java:42) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.data.CustomRendererLoader.<init>(CustomRendererLoader.java:48) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.data.CustomRendererLoader.<clinit>(CustomRendererLoader.java:42) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.Accessories.init(Accessories.java:116) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.fabric.AccessoriesFabric.onInitialize(AccessoriesFabric.java:77) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:405) ~[fabric-loader-0.18.4.jar:?]
        ... 6 more
Caused by: org.spongepowered.asm.mixin.transformer.throwables.IllegalClassLoadError: Illegal classload request for io.wispforest.accessories.mixin.SimpleJsonResourceReloadListenerAccessor. Mixin is defined in accessories-common.mixins.json and cannot be referenced directly
        at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:323) ~[sponge-mixin-0.17.0+mixin.0.8.7.jar:0.17.0+mixin.0.8.7]
        at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClass(MixinTransformer.java:237) ~[sponge-mixin-0.17.0+mixin.0.8.7.jar:0.17.0+mixin.0.8.7]
        at org.spongepowered.asm.mixin.transformer.MixinTransformer.transformClassBytes(MixinTransformer.java:202) ~[sponge-mixin-0.17.0+mixin.0.8.7.jar:0.17.0+mixin.0.8.7]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getPostMixinClassByteArray(KnotClassDelegate.java:435) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.tryLoadClass(KnotClassDelegate.java:336) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.loadClass(KnotClassDelegate.java:231) ~[fabric-loader-0.18.4.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:119) ~[fabric-loader-0.18.4.jar:?]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
        at knot/io.wispforest.accessories.utils.EndecDataLoader.setupCodec(EndecDataLoader.java:57) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.utils.EndecDataLoader.<init>(EndecDataLoader.java:53) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.utils.ManagedEndecDataLoader.<init>(ManagedEndecDataLoader.java:42) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.data.CustomRendererLoader.<init>(CustomRendererLoader.java:48) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.data.CustomRendererLoader.<clinit>(CustomRendererLoader.java:42) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.Accessories.init(Accessories.java:116) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at knot/io.wispforest.accessories.fabric.AccessoriesFabric.onInitialize(AccessoriesFabric.java:77) ~[accessories-fabric-1.2.19-beta+1.21.4.jar:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:405) ~[fabric-loader-0.18.4.jar:?]
        ... 6 more
```