### PR TITLE
fix: Crash on right click of Ownable Entities if owner is offline

### DIFF
--- a/common/src/main/java/io/wispforest/accessories/Accessories.java
+++ b/common/src/main/java/io/wispforest/accessories/Accessories.java
@@ -94,7 +94,7 @@ public class Accessories {
 
             if(type.is(AccessoriesTags.MODIFIABLE_ENTITY_BLACKLIST)) return TriState.FALSE;
 
-            var isOwnersPet = (target instanceof OwnableEntity ownableEntity && ownableEntity.getOwner().equals(player));
+            var isOwnersPet = (target instanceof OwnableEntity ownableEntity && player.equals(ownableEntity.getOwner()));
 
             if(isOwnersPet || type.is(AccessoriesTags.MODIFIABLE_ENTITY_WHITELIST)) return TriState.TRUE;
 


### PR DESCRIPTION
Initial solution was to add a null-check, but as player is not set as `nullable`, swapping the order seems to work just as well. If player *isn't* truly `not-null`, a null check would suffice too.

To reproduce the bug, simply right-clicking any ownable entity with an accessory in-hand, or by attempting to open the entity's Accessories Menu would crash the game to desktop.