### PR TITLE
Add Brazilian Portuguese (pt_br) translation

### DIFF
--- a/common/src/main/resources/assets/accessories/lang/pt_br.json
+++ b/common/src/main/resources/assets/accessories/lang/pt_br.json
@@ -1,0 +1,650 @@
+{
+  "accessories.slot.tooltip.singular": "Slot: ",
+  "accessories.slot.tooltip.plural": "Slots: ",
+  "accessories.cosmetic_slot.tooltip.singular": "Slot cosmético: ",
+  "accessories.cosmetic_slot.tooltip.plural": "Slots cosméticos: ",
+  "accessories.slot.any": "Qualquer",
+  "accessories.slot.except": " exceto ",
+  "accessories.tooltip.attributes.any": "Quando equipado:",
+  "accessories.tooltip.attributes.slot": "Quando equipado em %s:",
+  "accessories.tooltip.currently_equipped_in": "Equipado em: ",
+  "accessories.tooltip.equipment_reasoning": "Justificativa do equipamento: ",
+  "accessories.tooltip.accessory_reasoning": "Justificativa do acessório: ",
+  "accessories.tooltip.slot.invalid": "",
+  "accessories.tooltip.slot.valid": "",
+  "accessories.tooltip.slot.irrelevant": "",
+  "accessories.tooltip.extra_info": "Segure  para mostrar mais informações. ",
+  "accessories.tooltip.extra_info.list.entry_separator": ", ",
+  "accessories.tooltip.extra_info.2_or_more": " ou ",
+  "accessories.tooltip.equipment_reasoning.list_entry.invalid": "",
+  "accessories.tooltip.equipment_reasoning.list_entry.valid": "",
+  "accessories.tooltip.equipment_reasoning.list_entry.irrelevant": "",
+  "accessories.tooltip.equipment_reasoning.indent_entry": "",
+  "accessories.tooltip.list_entry": " ‐ ",
+  "accessories.tooltip.indent_entry": "   ",
+  "accessories.tooltip.validator.simplied_message.valid": "Pode ser equipado no slot.",
+  "accessories.tooltip.validator.simplied_message.invalid": "Não pode ser equipado no slot.",
+  "accessories.tooltip.validator.simplied_message.irrelevant": "Isto é irrelevante para o slot indicado.",
+  "accessories.tooltip.validator.always_valid": "Qualquer coisa cabe neste slot!.",
+  "accessories.tooltip.validator.always_invalid": "O slot não pode receber nenhum Acessório, para sempre!",
+  "accessories.tooltip.validator.tag.simple.valid": "Válido para o(s) grupo(s) indicado(s).",
+  "accessories.tooltip.validator.tag.simple.invalid": "Inválido para o(s) grupo(s) indicado(s).",
+  "accessories.tooltip.validator.tag.entry_separator": ", ",
+  "accessories.tooltip.validator.tag.advanced.valid.any": "A entrada está em um dos grupo(s): ",
+  "accessories.tooltip.validator.tag.advanced.valid.all": "A entrada está em todos os grupo(s): ",
+  "accessories.tooltip.validator.tag.advanced.invalid.any": "A entrada não está em nenhum dos grupo(s): ",
+  "accessories.tooltip.validator.tag.advanced.invalid.all": "A entrada não está em todos os grupo(s): ",
+  "accessories.tooltip.validator.set.entry_separator": ", ",
+  "accessories.tooltip.validator.set.simple.valid": "Válido para o grupo  indicado.",
+  "accessories.tooltip.validator.set.simple.invalid": "Inválido para o grupo  indicado.",
+  "accessories.tooltip.validator.set.advanced.valid": "A entrada é um dos  válidos: ",
+  "accessories.tooltip.validator.set.advanced.invalid": "A entrada não é nenhum dos  válidos: ",
+  "minecraft.entity_type.singular": "Entidade",
+  "minecraft.entity_type.plural": "Entidades",
+  "accessories.tooltip.validator.cursed": "Está preso a você até a morte!",
+  "accessories.tooltip.validator.attribute.simple.include": "Contém atributos para o slot indicado.",
+  "accessories.tooltip.validator.attribute.simple.excludes": "Não contém atributos para o slot indicado.",
+  "accessories.tooltip.validator.component.entry_separator": ", ",
+  "accessories.tooltip.validator.component.advanced.invalid": "Inválido por ser explicitamente proibido: ",
+  "accessories.tooltip.validator.component.advanced.valid": "Válido por ser explicitamente permitido: ",
+  "accessories.tooltip.validator.component.advanced.irrelevant": "Irrelevante por não ser explicitamente permitido: ",
+  "accessories.tooltip.validator.component.simple.irrelevant": "Irrelevante por não ser explicitamente permitido.",
+  "accessories.slot.hat": "Chapéu",
+  "accessories.slot.face": "Rosto",
+  "accessories.slot.cape": "Capa",
+  "accessories.slot.necklace": "Colar",
+  "accessories.slot.back": "Costas",
+  "accessories.slot.hand": "Mão",
+  "accessories.slot.ring": "Anel",
+  "accessories.slot.wrist": "Pulso",
+  "accessories.slot.belt": "Cinto",
+  "accessories.slot.anklet": "Tornozeleira",
+  "accessories.slot.shoes": "Sapatos",
+  "accessories.slot.charm": "Amuleto",
+  "tag.item.accessories.hat": "Chapéu",
+  "tag.item.accessories.face": "Rosto",
+  "tag.item.accessories.cape": "Capa",
+  "tag.item.accessories.necklace": "Colar",
+  "tag.item.accessories.back": "Costas",
+  "tag.item.accessories.hand": "Mão",
+  "tag.item.accessories.ring": "Anel",
+  "tag.item.accessories.wrist": "Pulso",
+  "tag.item.accessories.belt": "Cinto",
+  "tag.item.accessories.anklet": "Tornozeleira",
+  "tag.item.accessories.shoes": "Sapatos",
+  "tag.item.accessories.charm": "Amuleto",
+  "tag.item.accessories.any": "Qualquer",
+  "accessories.slot.accessories.head": "Cabeça",
+  "accessories.slot.accessories.chest": "Peito",
+  "accessories.slot.accessories.legs": "Pernas",
+  "accessories.slot.accessories.feet": "Pés",
+  "accessories.slot.accessories.animal_body": "Corpo",
+  "accessories.slot_group.misc": "Diversos",
+  "accessories.slot_group.head": "Cabeça",
+  "accessories.slot_group.chest": "Peito",
+  "accessories.slot_group.arm": "Braços",
+  "accessories.slot_group.leg": "Pernas",
+  "accessories.slot_group.feet": "Pés",
+  "accessories.slot_group.unsorted": "Não ordenado",
+  "key.category.accessories.main": "Acessórios",
+  "accessories.key.open_accessories_screen": "Abrir tela de Acessórios",
+  "accessories.key.open_others_accessories_screen": "Abrir tela de Acessórios de outro",
+  "accessories.commands.attribute.failed.modifier_already_present_itemstack": "O modificador %s já está presente no atributo %s para a pilha %s",
+  "accessories.commands.attribute.failed.no_modifier_itemstack": "O atributo %s para a pilha %s não tem o modificador %s",
+  "accessories.commands.attribute.modifier.add.success_itemstack": "Adicionado o modificador %s ao atributo %s para a pilha %s",
+  "accessories.commands.attribute.modifier.remove.success_itemstack": "Removido o modificador %s do atributo %s para a pilha %s",
+  "accessories.commands.attribute.modifier.value.get.success_itemstack": "O valor do modificador %s no atributo %s para a pilha %s é %s",
+  "accessories.commands.attribute.value.get.success": "O valor do atributo %s para a entidade %s é %s",
+  "accessories.commands.slot.value.get.success": "O valor do slot %s para a entidade %s é %s",
+  "accessories.commands.slot.modifier.clear.all.success": "Os atributos de slot de todos os recipientes foram removidos para a entidade %s",
+  "accessories.commands.slot.modifier.clear.container.success": "Os atributos de slot de %s foram removidos para a entidade %s",
+  "accessories.argument.livingEntities.nonLiving": "Apenas entidades vivas podem ser afetadas por este comando, mas o seletor fornecido inclui entidades não vivas",
+  "accessories.commands.feature.toggle.failure": "'%s' não corresponde a nenhum dos recursos alternáveis: %s",
+  "accessories.commands.feature.toggle.on": "'%s' foi ativado!",
+  "accessories.commands.feature.toggle.off": "'%s' foi desativado!",
+  "accessories.commands.dump.failure": "'%s' não corresponde a nenhum dos tipos válidos para registro: %s",
+  "accessories.commands.dump.success": "Os dados de '%s' foram despejados no arquivo de log!",
+  "accessories.commands.slot.modifier.addition": "O atributo '%s' foi adicionado ao slot `%s` para '%s'",
+  "accessories.commands.slot.modifier.removed.failure": "O atributo '%s' para o slot '%s' não foi encontrado para '%s'!",
+  "accessories.commands.slot.modifier.removed.success": "O atributo '%s' foi removido do slot '%s' de '%s'!",
+  "accessories.commands.nest.addition": "Item inserido adicionado à pilha da mão principal!",
+  "accessories.commands.slot.validation.added.valid": "'%s' foi adicionado como um slot válido",
+  "accessories.commands.slot.validation.added.invalid": "'%s' foi adicionado como um slot inválido",
+  "accessories.commands.slot.validation.removed.valid": "'%s' foi removido como um slot válido",
+  "accessories.commands.slot.validation.removed.invalid": "'%s' foi removido como um slot inválido",
+  "gamerule.accessories.keepAccessoryInventory": "Manter Inventário de Acessórios",
+  "#comment": "Config Related Below",
+  "accessories.slot.cosmetics.toggle.show": "Mostrar Slots Cosméticos",
+  "accessories.slot.cosmetics.toggle.hide": "Ocultar Slots Cosméticos",
+  "accessories.display.toggle.show": "Mostrar Acessório",
+  "accessories.display.toggle.hide": "Ocultar Acessório",
+  "accessories.lines.toggle.show": "Mostrar todas as linhas",
+  "accessories.lines.toggle.hide": "Ocultar todas as linhas",
+  "accessories.unused_slots.toggle.show": "Mostrar Slots Não Usados",
+  "accessories.unused_slots.toggle.hide": "Ocultar Slots Não Usados",
+  "accessories.slot_cosmetics.toggle.enabled": "Mostrar Slots de Acessórios",
+  "accessories.slot_cosmetics.toggle.disabled": "Mostrar Slots Cosméticos",
+  "accessories.advanced_options.toggle.enabled.tooltip": "Ocultar opções de tela",
+  "accessories.advanced_options.toggle.disabled.tooltip": "Mostrar opções de tela",
+  "accessories.unused_slots.label": "Mostrar slots não usados:",
+  "accessories.unused_slots.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "✔",
+      "color": "#28FFBF"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Visível"
+  ],
+  "accessories.unused_slots.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "❌",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Oculto"
+  ],
+  "accessories.unused_slots.toggle.enabled.tooltip": "Ocultar todos os Slots Não Usados",
+  "accessories.unused_slots.toggle.disabled.tooltip": "Mostrar todos os Slots Não Usados",
+  "accessories.column_amount.label": "Quantidade de colunas de Acessórios:",
+  "accessories.column_amount.tooltip": "Ajusta a quantidade de colunas do Módulo de Acessórios",
+  "accessories.side_by_side_slots.label": "Modo de visualização de Slot Cosmético:",
+  "accessories.side_by_side_slots.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "O",
+      "color": "#eab676"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Alternar"
+  ],
+  "accessories.side_by_side_slots.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "/",
+      "color": "#1e81b0"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Trocar"
+  ],
+  "accessories.side_by_side_slots.toggle.enabled.tooltip": "Mude para alternar entre slots",
+  "accessories.side_by_side_slots.toggle.disabled.tooltip": "Mude para mostrar ou ocultar slots cosméticos",
+  "accessories.side_by_side_entity.label": "Quantidade de visualizações de Entidade:",
+  "accessories.side_by_side_entity.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "||",
+      "color": "#32a852"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Duplo"
+  ],
+  "accessories.side_by_side_entity.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "|",
+      "color": "#32a852"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Único"
+  ],
+  "accessories.side_by_side_entity.toggle.enabled.tooltip": "Trocar para alternar a visualização de entidade única",
+  "accessories.side_by_side_entity.toggle.disabled.tooltip": "Trocar para alternar a visualização de entidade dupla",
+  "accessories.entity_centered.label": "Centralização do painel de entidade:",
+  "accessories.entity_centered.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "✔",
+      "color": "#28FFBF"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Ativado"
+  ],
+  "accessories.entity_centered.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "❌",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Desativado"
+  ],
+  "accessories.entity_centered.toggle.enabled.tooltip": "Permitir que a entidade seja deslocada do centro",
+  "accessories.entity_centered.toggle.disabled.tooltip": "Fazer a entidade SEMPRE ficar perto ou no centro da tela",
+  "accessories.widget_type.label": "Variante do widget de acessório:",
+  "accessories.widget_type.paginated": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "☰",
+      "color": "#347ecf"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Paginado"
+  ],
+  "accessories.widget_type.scrollable": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "⏷",
+      "color": "#953abd"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Rolável"
+  ],
+  "accessories.widget_type.paginated.tooltip": "Usa páginas para navegar pelos slots de Acessórios",
+  "accessories.widget_type.scrollable.tooltip": "Usa rolagem para navegar pelos slots de Acessórios",
+  "accessories.main_widget_position.label": "Posição do widget de Acessórios:",
+  "accessories.main_widget_position.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "←",
+      "color": "#32a852"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Esquerda"
+  ],
+  "accessories.main_widget_position.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "→",
+      "color": "#32a852"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Direita"
+  ],
+  "accessories.main_widget_position.toggle.enabled.tooltip": "Mover o widget de Acessórios para a direita",
+  "accessories.main_widget_position.toggle.disabled.tooltip": "Mover o widget de Acessórios para a esquerda",
+  "accessories.group_filter.label": "Widget de filtro de grupo:",
+  "accessories.group_filter.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "✔",
+      "color": "#28FFBF"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Visível"
+  ],
+  "accessories.group_filter.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "❌",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Oculto"
+  ],
+  "accessories.group_filter.toggle.enabled.tooltip": "Ocultar o widget de filtro de grupo",
+  "accessories.group_filter.toggle.disabled.tooltip": "Mostrar o widget de filtro de grupo",
+  "accessories.side_widget_position.label": "Posição do widget lateral:",
+  "accessories.side_widget_position.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "()",
+      "color": "#32a852"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Juntos"
+  ],
+  "accessories.side_widget_position.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "||",
+      "color": "#32a852"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Separados"
+  ],
+  "accessories.side_widget_position.toggle.enabled.tooltip": "Mover o widget lateral para junto do widget de Acessórios",
+  "accessories.side_widget_position.toggle.disabled.tooltip": "Mover o widget lateral para o lado oposto ao widget de Acessórios",
+  "accessories.dark_mode_toggle.label": "Tema da tela:",
+  "accessories.dark_mode_toggle.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "☽",
+      "color": "#3d29c2"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Escuro"
+  ],
+  "accessories.dark_mode_toggle.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "☀",
+      "color": "#bffa9b"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Claro"
+  ],
+  "accessories.dark_mode_toggle.toggle.enabled.tooltip": "Alterar o tema para o modo claro",
+  "accessories.dark_mode_toggle.toggle.disabled.tooltip": "Alterar o tema para o modo escuro",
+  "accessories.show_equipped_stack_slot_type.label": "Mostrar tipo equipado:",
+  "accessories.show_equipped_stack_slot_type.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "✔",
+      "color": "#28FFBF"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Visível"
+  ],
+  "accessories.show_equipped_stack_slot_type.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "❌",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Oculto"
+  ],
+  "accessories.show_equipped_stack_slot_type.toggle.enabled.tooltip": "Ocultar o tipo de slot da pilha equipada",
+  "accessories.show_equipped_stack_slot_type.toggle.disabled.tooltip": "Mostrar o tipo de slot da pilha equipada",
+  "accessories.entity_look_at_cursor.label": "Entidade olha para o mouse:",
+  "accessories.entity_look_at_cursor.toggle.enabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "✔",
+      "color": "#28FFBF"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Ativado"
+  ],
+  "accessories.entity_look_at_cursor.toggle.disabled": [
+    "",
+    {
+      "text": "[",
+      "color": "gray"
+    },
+    {
+      "text": "❌",
+      "color": "#EB1D36"
+    },
+    {
+      "text": "]",
+      "color": "gray"
+    },
+    " Desativado"
+  ],
+  "accessories.entity_look_at_cursor.toggle.enabled.tooltip": "Desativar o olhar para o cursor",
+  "accessories.entity_look_at_cursor.toggle.disabled.tooltip": "Ativar o olhar para o cursor",
+  "accessories.crafting_grid.toggle.enabled.tooltip": "Ocultar a grade de criação",
+  "accessories.crafting_grid.toggle.disabled.tooltip": "Mostrar a grade de criação",
+  "accessories.selection_screen.message": [
+    "Abaixo está um conjunto de opções de tela que você \n",
+    "pode escolher dependendo do estilo do \n",
+    "Modpack ou do seu estilo de jogo. \n\n",
+    "Observe que você pode alterar isso dentro das \n",
+    "Configurações do Accessories se a opção dada não for \n",
+    "do seu agrado."
+  ],
+  "accessories.back.screen": "Voltar à tela anterior",
+  "accessories.open.screen": "Abrir tela de Acessórios",
+  "accessories.reset.group_filter": "Redefinir filtros de grupo",
+  "text.config.accessories.title": "Configurações do Accessories",
+  "text.config.accessories.option.useExperimentalCaching": "Usar cache experimental",
+  "text.config.accessories.option.useExperimentalCaching.tooltip": [
+    "Tenta armazenar em cache várias consultas de ItemStack\n",
+    "para ter mais desempenho, mas pode causar problemas."
+  ],
+  "text.config.accessories.category.contentOptions": "Opções de Conteúdo",
+  "text.config.accessories.category.contentOptions.tooltip": [
+    "Contém mais opções focadas em conteúdo, como a possibilidade de equipar planador e totem"
+  ],
+  "text.config.accessories.option.contentOptions.validGliderSlots": "Slots válidos para planador",
+  "text.config.accessories.option.contentOptions.validGliderSlots.tooltip": [
+    "Adiciona os slots nos quais um item de planador pode ser equipado."
+  ],
+  "text.config.accessories.option.contentOptions.allowGliderEquip": "Permitir equipar planadores",
+  "text.config.accessories.option.contentOptions.allowGliderEquip.tooltip": [
+    "Alterna a capacidade de equipar planadores nos slots de Acessórios."
+  ],
+  "text.config.accessories.option.contentOptions.validTotemSlots": "Slots válidos para totem",
+  "text.config.accessories.option.contentOptions.validTotemSlots.tooltip": [
+    "Adiciona os slots nos quais um item de totem pode ser equipado."
+  ],
+  "text.config.accessories.option.contentOptions.allowTotemEquip": "Permitir equipar totens",
+  "text.config.accessories.option.contentOptions.allowTotemEquip.tooltip": [
+    "Alterna a capacidade de equipar totens nos slots de Acessórios."
+  ],
+  "text.config.accessories.option.contentOptions.validBannerSlots": "Slots válidos para estandarte",
+  "text.config.accessories.option.contentOptions.validBannerSlots.tooltip": [
+    "Adiciona os slots nos quais um item de estandarte pode ser equipado."
+  ],
+  "text.config.accessories.option.contentOptions.allowBannerEquip": "Permitir equipar estandartes",
+  "text.config.accessories.option.contentOptions.allowBannerEquip.tooltip": [
+    "Alterna a capacidade de equipar estandartes nos slots de Acessórios."
+  ],
+  "text.config.accessories.category.clientOptions": "Opções de Cliente",
+  "text.config.accessories.category.clientOptions.tooltip": [
+    "Contém opções mais genéricas do lado do cliente para renderização ou entrada do jogador"
+  ],
+  "text.config.accessories.option.clientOptions.forceNullRenderReplacement": "Forçar substituição de renderização vazia",
+  "text.config.accessories.option.clientOptions.forceNullRenderReplacement.tooltip": "Força qualquer renderizador registrado que não esteja\nrenderizando a usar a renderização padrão.",
+  "text.config.accessories.option.clientOptions.disableEmptySlotScreenError": "Desativar erro de acessório vazio",
+  "text.config.accessories.option.clientOptions.disableEmptySlotScreenError.tooltip": "Desativa a mensagem de erro exibida se a tela de Acessórios\nfor aberta e nenhum slot usado for encontrado.",
+  "text.config.accessories.option.clientOptions.showCosmeticAccessories": "Mostrar renderização cosmética de itens",
+  "text.config.accessories.option.clientOptions.showCosmeticAccessories.tooltip": "Ativa/Desativa a renderização de variantes cosméticas de itens se equipadas.",
+  "text.config.accessories.option.clientOptions.disabledDefaultRenders": "Renderização padrão desativada",
+  "text.config.accessories.option.clientOptions.disabledDefaultRenders.tooltip": "Desativa a renderização padrão de itens do renderizador incluído, se estiver em uso.",
+  "text.config.accessories.option.clientOptions.equipControl": "Modo de equipar rápido com a mão",
+  "text.config.accessories.option.clientOptions.equipControl.tooltip": "Altera o modo usado para equipar rapidamente uma pilha da sua mão.",
+  "text.config.accessories.enum.playerEquipControl.must_crouch": "Exige agachar",
+  "text.config.accessories.enum.playerEquipControl.must_not_crouch": "Sem agachar",
+  "text.config.accessories.enum.playerEquipControl.disabled": "Desativado",
+  "text.config.accessories.option.screenOptions.prioritizeCreativeScreen": "Priorizar abertura da tela do Criativo",
+  "text.config.accessories.option.screenOptions.prioritizeCreativeScreen.tooltip": "Tentará abrir a tela do Criativo em vez da tela de Acessórios\nenquanto estiver no modo criativo.",
+  "text.config.accessories.category.screenOptions": "Opções de Tela",
+  "text.config.accessories.category.screenOptions.tooltip": "Contém todas as opções de configuração de tela para todas as variantes e o deslocamento do botão injetado",
+  "text.config.accessories.option.screenOptions.selectedScreenType": "Tipo de tela selecionado",
+  "text.config.accessories.option.screenOptions.selectedScreenType.tooltip": "Usado para ajustar qual tela será usada; nenhuma\nexibirá um aviso para a seleção do usuário.",
+  "text.config.accessories.enum.screenType.none": "Indefinido",
+  "text.config.accessories.enum.screenType.original": "Original",
+  "text.config.accessories.enum.screenType.experimental_v1": "Experimental",
+  "text.config.accessories.section.accessories_screen": "Opções específicas da tela de Acessórios",
+  "text.config.accessories.option.screenOptions.defaultValues": "Opções globais de tela",
+  "text.config.accessories.option.screenOptions.defaultValues.tooltip": "Usado para ajustar as opções PADRÃO de tela, como quantidade de colunas,\no tema definido, etc. Isso também pode ser ajustado no jogo por usuário.",
+  "text.config.accessories.option.screenOptions.backButtonClosesScreen": "Fechar a tela em vez de voltar à tela anterior",
+  "text.config.accessories.option.screenOptions.backButtonClosesScreen.tooltip": "Tenta fechar a tela em vez de voltar à tela de inventário anterior, se possível.",
+  "text.config.accessories.option.screenOptions.keybindIgnoresOtherTargets": "Tecla de abrir tela ignora outros alvos",
+  "text.config.accessories.option.screenOptions.keybindIgnoresOtherTargets.tooltip": "Útil se você quiser que a tecla ignore outros alvos encontrados, como o animal que você está montando.",
+  "text.config.accessories.option.screenOptions.showUnusedSlots": "Mostrar slots não usados",
+  "text.config.accessories.option.screenOptions.showUnusedSlots.tooltip": "Alterna a filtragem de slots não usados",
+  "text.config.accessories.option.screenOptions.allowSlotScrolling": "Permitir rolagem de slots na tela",
+  "text.config.accessories.option.screenOptions.allowSlotScrolling.tooltip": "Útil se o mod em questão permitir a rolagem de pilhas,\no que causa problemas ao percorrer os acessórios.",
+  "text.config.accessories.option.screenOptions.showEquippedStackSlotType": "Mostrar tipo de slot das pilhas equipadas",
+  "text.config.accessories.option.screenOptions.showEquippedStackSlotType.tooltip": "Mostra na dica o tipo de slot em que a pilha está equipada.",
+  "text.config.accessories.option.screenOptions.entityLooksAtMouseCursor": "Fazer a entidade seguir o cursor do mouse",
+  "text.config.accessories.option.screenOptions.entityLooksAtMouseCursor.tooltip": "Se ativado, faz a entidade seguir o cursor do mouse;\ncaso contrário, permite a rotação manual da entidade.",
+  "text.config.accessories.option.screenOptions.allowSideBarCraftingGrid": "Permitir grade de criação na barra lateral",
+  "text.config.accessories.option.screenOptions.allowSideBarCraftingGrid.tooltip": "Se não houver filtros de grupo, tentará colocar\na grade de criação na barra lateral em vez de abaixo.",
+  "text.config.accessories.section.button_offsets": "Deslocamentos de botões injetados",
+  "text.config.accessories.option.screenOptions.inventoryButtonOffset": "Deslocamento do botão do inventário",
+  "text.config.accessories.option.screenOptions.menuButtonInjections": "Botões de tela injetados",
+  "text.config.accessories.option.screenOptions.menuButtonInjections.menuType": "ID do menu",
+  "text.config.accessories.option.screenOptions.menuButtonInjections.xOffset": "Deslocamento X",
+  "text.config.accessories.option.screenOptions.menuButtonInjections.yOffset": "Deslocamento Y",
+  "text.config.accessories.option.screenOptions.menuButtonInjections.mini": "É versão mini",
+  "text.config.accessories.option.screenOptions.alwaysShowCraftingGrid": "Sempre mostrar a grade de criação",
+  "text.config.accessories.option.screenOptions.alwaysShowCraftingGrid.tooltip": "Removerá o botão de alternância da grade de criação e a mostrará sempre na tela experimental.",
+  "text.config.accessories.option.screenOptions.equipCheckTooltipType": "Tipo de verificação de dica de equipamento",
+  "text.config.accessories.option.screenOptions.equipCheckTooltipType.tooltip": "Altera quanta informação é desativada sobre se um acessório pode ser equipado em um determinado slot ou desequipado de um determinado slot",
+  "text.config.accessories.option.screenOptions.showSlotDarkeningEffect": "Mostrar efeito de escurecimento de slot",
+  "text.config.accessories.option.screenOptions.showSlotDarkeningEffect.tooltip": "Alterna se o escurecimento de slot ao equipar ou desequipar itens é mostrado na tela de Acessórios",
+  "text.config.accessories.section.legacy": "Tela original",
+  "text.config.accessories.option.screenOptions.showGroupTabs": "Mostrar abas de grupo para busca rápida",
+  "text.config.accessories.option.screenOptions.showGroupTabs.tooltip": "Alterna se as abas de grupo dentro da tela original são mostradas ou ocultadas.",
+  "text.config.accessories.section.hover": "Efeitos sob o cursor",
+  "text.config.accessories.category.screenOptions.hoveredOptions": "Opções sob o cursor",
+  "text.config.accessories.category.screenOptions.hoveredOptions.tooltip": "Opções para controlar os efeitos de renderização da entrada sob o cursor.",
+  "text.config.accessories.option.screenOptions.hoveredOptions.brightenHovered": "Clarear sob o cursor",
+  "text.config.accessories.option.screenOptions.hoveredOptions.cycleBrightness": "Ciclo de brilho",
+  "text.config.accessories.option.screenOptions.hoveredOptions.line": "Desenhar linha",
+  "text.config.accessories.option.screenOptions.hoveredOptions.clickbait": "Clickbait",
+  "text.config.accessories.category.screenOptions.unHoveredOptions": "Opções fora do cursor",
+  "text.config.accessories.category.screenOptions.unHoveredOptions.tooltip": "Opções para controlar os efeitos de renderização das entradas fora do cursor.",
+  "text.config.accessories.option.screenOptions.unHoveredOptions.renderUnHovered": "Renderizar fora do cursor",
+  "text.config.accessories.option.screenOptions.unHoveredOptions.darkenUnHovered": "Escurecer fora do cursor",
+  "text.config.accessories.option.screenOptions.unHoveredOptions.darkenedBrightness": "Brilho escurecido",
+  "text.config.accessories.option.screenOptions.unHoveredOptions.darkenedOpacity": "Opacidade escurecida",
+  "text.config.accessories.option.disabledDefaultRenders": "Renderizadores padrão desativados",
+  "text.config.accessories.option.disabledDefaultRenders.tooltip": "Útil para desativar a renderização padrão de um determinado slot, seja\nespecificamente para renderizações de bloco e/ou item",
+  "text.config.accessories.option.clientOptions.disabledDefaultRenders.slotType": "Slot",
+  "text.config.accessories.option.clientOptions.disabledDefaultRenders.targetType": "Tipo",
+  "text.config.accessories.enum.targetType.item": "Item",
+  "text.config.accessories.enum.targetType.block": "Bloco",
+  "text.config.accessories.enum.targetType.all": "Tudo",
+  "text.config.accessories.option.modifiers": "Modificadores de quantidade de slot",
+  "text.config.accessories.option.modifiers.tooltip": "Útil para adicionar valores de deslocamento a um determinado tipo de slot sem\nprecisar de um pacote de dados, pois permite tanto valores de deslocamento\npositivos quanto negativos.",
+  "text.config.accessories.option.modifiers.slotType": "Slot",
+  "text.config.accessories.option.modifiers.amount": "Deslocamento",
+  "text.config.accessories.enum.tooltipInfoType.all": "Tudo",
+  "text.config.accessories.enum.tooltipInfoType.advanced": "Avançado",
+  "text.config.accessories.enum.tooltipInfoType.basic": "Básico",
+  "text.config.accessories.enum.tooltipInfoType.disabled": "Desativado"
+}


### PR DESCRIPTION
There wasn't a Brazilian Portuguese translation for Accessories yet, so here's a complete one covering all 292 strings: the slot names, the accessories screen, commands and tooltips. All placeholders are preserved and I went with natural pt-BR inventory wording for the slot types. Glad to keep it in sync as the API evolves.